### PR TITLE
fix incorrect su command

### DIFF
--- a/app/src/main/java/com/fei_ke/greyscale/Util.java
+++ b/app/src/main/java/com/fei_ke/greyscale/Util.java
@@ -15,7 +15,7 @@ import android.widget.Toast;
 public class Util {
     private static final String PERMISSION = "android.permission.WRITE_SECURE_SETTINGS";
     private static final String COMMAND    = "adb shell pm grant " + BuildConfig.APPLICATION_ID + " " + PERMISSION;
-    private static final String SU_COMMAND = "su -c pm grant " + BuildConfig.APPLICATION_ID + " " + PERMISSION;
+    private static final String SU_COMMAND = "su -c 'pm grant " + BuildConfig.APPLICATION_ID + " " + PERMISSION + "'";
 
     private static final String DISPLAY_DALTONIZER_ENABLED = "accessibility_display_daltonizer_enabled";
     private static final String DISPLAY_DALTONIZER         = "accessibility_display_daltonizer";


### PR DESCRIPTION
If the su command is called like this: `su -c command argument`
It will be evaluated as: `su -c "command" argument` which makes su think we are calling command without arguments as an user called "argument".
And not `su -c "command argument"`
I added single quotes to fix the problem.